### PR TITLE
download v3-compatible lightweight-jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,8 +79,6 @@ workflows:
   version: 2
   test:
     jobs:
-      - test
-    jobs:
       - test:
           filters:
             branches:

--- a/install.sh
+++ b/install.sh
@@ -501,6 +501,6 @@ fi
 
 # download hysds core packages and docker registry image if mozart
 if [[ "$COMPONENT" == "mozart" ]]; then
-  ${BASE_PATH}/download_latest.py $API_URL hysds lightweight-jobs -o ${INSTALL_DIR}/pkgs -s sdspkg.tar
+  ${BASE_PATH}/download_latest.py $API_URL hysds lightweight-jobs -o ${INSTALL_DIR}/pkgs -r "^container-hysds_lightweight-jobs-v0"
   ${BASE_PATH}/download_latest.py $API_URL hysds hysds-dockerfiles -o ${INSTALL_DIR}/pkgs -r "^docker-registry"
 fi


### PR DESCRIPTION
If using `develop-es1` branch of hysds-framework to install HySDS, only the the `v0` lightweight-job HySDS package is compatible. Here we use a regex instead to filter on the latest v3.