### PR TITLE
HC-269: integration SDSWatch into cluster deployment

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -508,6 +508,7 @@ if [[ "$COMPONENT" == "mozart" ]]; then
   # download hysds core packages and docker registry image if mozart
   ${BASE_PATH}/download_latest.py $API_URL hysds lightweight-jobs -o ${INSTALL_DIR}/pkgs -r "^container-hysds_lightweight-jobs-v1"
   ${BASE_PATH}/download_latest.py $API_URL hysds hysds-dockerfiles -o ${INSTALL_DIR}/pkgs -r "^docker-registry"
+  ${BASE_PATH}/download_latest.py $API_URL hysds hysds-dockerfiles -o ${INSTALL_DIR}/pkgs -r "^logstash-"
 
   # build hysds_ui
   install_hysds_ui $OPS hysds_ui


### PR DESCRIPTION
This PR includes updates to integrate SDSWatch into HySDS core and cluster provisioning. The assumption is that we re-using the ELK stack installed on the metrics component/instance.

These updates were tested on a NISAR PCM dev cluster and end-to-end SDSWatch functionality verified according to https://hysds-core.atlassian.net/wiki/spaces/HYS/pages/548634892/SDSWatch#In-case-all-the-files-are-lost%2C-here-is-how-to-set-it-up.