### PR TITLE
hot fix: Base branch should be develop-centos7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -954,7 +954,7 @@ workflows:
           final_tag: develop-centos7
           framework_branch: develop
           hysds_release: develop
-          base_branch: develop
+          base_branch: develop-centos7
           context:
             - docker-hub-creds
             - git-oauth-token


### PR DESCRIPTION
Fix hysds-verdi-pge-base for centos7 to use the develop-centos7 branch as the base branch