### PR TITLE
added logstash-oss w/ opensearch to config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -736,17 +736,25 @@ jobs:
             docker pull registry:2
             docker save registry:2 > docker-registry-2.tar
             pigz -f docker-registry-2.tar
+
             docker pull hysds/verdi:develop-es1
             docker save hysds/verdi:develop-es1 > hysds-verdi-develop-es1.tar
             pigz -f hysds-verdi-develop-es1.tar
+
             docker pull hysds/logstash:7.1.1
             docker tag hysds/logstash:7.1.1 logstash:7.1.1
             docker save logstash:7.1.1 > logstash-7.1.1.tar
             pigz -f logstash-7.1.1.tar
+
             docker pull hysds/logstash:7.9.3
             docker tag hysds/logstash:7.9.3 logstash:7.9.3
             docker save logstash:7.9.3 > logstash-7.9.3.tar
             pigz -f logstash-7.9.3.tar
+
+            docker pull opensearchproject/logstash-oss-with-opensearch-output-plugin:7.16.3
+            docker tag opensearchproject/logstash-oss-with-opensearch-output-plugin:7.16.3 logstash-oss:7.16.3
+            docker save logstash-oss:7.16.3 > logstash-oss-7.16.3.tar
+            pigz -f logstash-oss-7.16.3.tar
       - persist_to_workspace:
           root: assets
           paths:


### PR DESCRIPTION
related ticket: https://hysds-core.atlassian.net/browse/HC-492

currently logstash 7.9.3 is not compatible to opensearch 2.7+ but the opensearch team released a version of logstash-oss with the opensearch output plugin installed, which is also backwards compatible with elasticsearch 7.10.2
- https://hub.docker.com/r/opensearchproject/logstash-oss-with-opensearch-output-plugin

i chose version 7.16.3 b/c its the latest release before v8 and also starting from 7.16.2 they patched the log4j vulnerability:
- https://www.elastic.co/blog/new-elasticsearch-and-logstash-releases-upgrade-apache-log4j2

the changes in hysds-framework are to pull the docker image for this new version of logstash-oss and upload it to its release assets. that way our HySDS cluster can use the logstash-oss

@pymonger would i need to run the circle CI job one more time before running the dev-e2e after merging in this PR?