### PR TITLE
HC-522: Pin setuptools to less than 70.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -897,7 +897,7 @@ workflows:
           puppet_branch: HC-522
           build_tag: ""
           final_tag: HC-522
-          framework_branch: develop
+          framework_branch: HC-522
           hysds_release: develop
           base_branch: HC-522
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -897,7 +897,7 @@ workflows:
           puppet_branch: HC-522
           build_tag: ""
           final_tag: HC-522
-          framework_branch: HC-522
+          framework_branch: develop
           hysds_release: HC-522
           base_branch: HC-522
           context:
@@ -913,7 +913,7 @@ workflows:
           puppet_branch: HC-522
           build_tag: ""
           final_tag: HC-522
-          framework_branch: HC-522
+          framework_branch: develop
           hysds_release: HC-522
           base_branch: HC-522
           context:
@@ -929,7 +929,7 @@ workflows:
           puppet_branch: HC-522
           build_tag: ""
           final_tag: HC-522
-          framework_branch: HC-522
+          framework_branch: develop
           hysds_release: HC-522
           base_branch: HC-522
           context:
@@ -945,7 +945,7 @@ workflows:
           puppet_branch: HC-522
           build_tag: ""
           final_tag: HC-522
-          framework_branch: HC-522
+          framework_branch: develop
           hysds_release: HC-522
           base_branch: HC-522
           context:
@@ -961,7 +961,7 @@ workflows:
           puppet_branch: HC-522
           build_tag: ""
           final_tag: HC-522
-          framework_branch: HC-522
+          framework_branch: develop
           hysds_release: HC-522
           base_branch: HC-522
           context:
@@ -977,7 +977,7 @@ workflows:
           puppet_branch: HC-522
           build_tag: ""
           final_tag: HC-522
-          framework_branch: HC-522
+          framework_branch: develop
           hysds_release: HC-522
           base_branch: HC-522
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -848,19 +848,19 @@ workflows:
             branches:
               only: develop
       - build-hysds_base:
-          branch: develop
+          branch: HC-522
           build_tag: ""
-          final_tag: develop
+          final_tag: HC-522
           context:
             - docker-hub-creds
             - git-oauth-token
           filters:
             branches:
-              only: develop
+              only: HC-522
       - build-hysds_dev:
-          branch: develop
+          branch: HC-522
           build_tag: ""
-          final_tag: develop
+          final_tag: HC-522
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -868,11 +868,11 @@ workflows:
             - build-hysds_base
           filters:
             branches:
-              only: develop
+              only: HC-522
       - build-hysds_cuda_base:
-          branch: develop
+          branch: HC-522
           build_tag: ""
-          final_tag: develop
+          final_tag: HC-522
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -880,11 +880,11 @@ workflows:
             - build-hysds_base
           filters:
             branches:
-              only: develop
+              only: HC-522
       - build-hysds_cuda_dev:
-          branch: develop
+          branch: HC-522
           build_tag: ""
-          final_tag: develop
+          final_tag: HC-522
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -892,14 +892,14 @@ workflows:
             - build-hysds_cuda_base
           filters:
             branches:
-              only: develop
+              only: HC-522
       - build-hysds_verdi_pge_base:
           puppet_branch: docker
           build_tag: ""
-          final_tag: develop
-          framework_branch: develop
-          hysds_release: develop
-          base_branch: develop
+          final_tag: HC-522
+          framework_branch: HC-522
+          hysds_release: HC-522
+          base_branch: HC-522
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -908,14 +908,14 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: develop
+              only: HC-522
       - build-hysds_cuda_pge_base:
-          puppet_branch: docker
+          puppet_branch: HC-522
           build_tag: ""
-          final_tag: develop
-          framework_branch: develop
-          hysds_release: develop
-          base_branch: develop
+          final_tag: HC-522
+          framework_branch: HC-522
+          hysds_release: HC-522
+          base_branch: HC-522
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -924,14 +924,14 @@ workflows:
             - build-hysds_cuda_dev
           filters:
             branches:
-              only: develop
+              only: HC-522
       - build-hysds_mozart:
-          puppet_branch: docker
+          puppet_branch: HC-522
           build_tag: ""
-          final_tag: develop
-          framework_branch: develop
-          hysds_release: develop
-          base_branch: develop
+          final_tag: HC-522
+          framework_branch: HC-522
+          hysds_release: HC-522
+          base_branch: HC-522
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -940,14 +940,14 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: develop
+              only: HC-522
       - build-hysds_metrics:
-          puppet_branch: docker
+          puppet_branch: HC-522
           build_tag: ""
-          final_tag: develop
-          framework_branch: develop
-          hysds_release: develop
-          base_branch: develop
+          final_tag: HC-522
+          framework_branch: HC-522
+          hysds_release: HC-522
+          base_branch: HC-522
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -956,14 +956,14 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: develop
+              only: HC-522
       - build-hysds_grq:
-          puppet_branch: docker
+          puppet_branch: HC-522
           build_tag: ""
-          final_tag: develop
-          framework_branch: develop
-          hysds_release: develop
-          base_branch: develop
+          final_tag: HC-522
+          framework_branch: HC-522
+          hysds_release: HC-522
+          base_branch: HC-522
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -972,14 +972,14 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: develop
+              only: HC-522
       - build-hysds_cont_int:
-          puppet_branch: docker
+          puppet_branch: HC-522
           build_tag: ""
-          final_tag: develop
-          framework_branch: develop
-          hysds_release: develop
-          base_branch: develop
+          final_tag: HC-522
+          framework_branch: HC-522
+          hysds_release: HC-522
+          base_branch: HC-522
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -988,10 +988,10 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: develop
+              only: HC-522
       - deploy:
           build_tag: ""
-          final_tag: develop
+          final_tag: HC-522
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -999,7 +999,7 @@ workflows:
             - build-hysds_verdi_pge_base
           filters:
             branches:
-              only: develop
+              only: HC-522
   build-deploy-release:
     jobs:
       - build-redis:
@@ -1201,36 +1201,36 @@ workflows:
               only: /^v5.*/
             branches:
               ignore: /.*/
-      - deploy:
-          build_tag: $CIRCLE_TAG
-          final_tag: latest
-          context:
-            - docker-hub-creds
-            - git-oauth-token
-          requires:
-            - build-hysds_verdi_pge_base
-          filters:
-            tags:
-              only: /^v5.*/
-            branches:
-              ignore: /.*/
-      - export-support-assets:
-          context:
-            - docker-hub-creds
-            - git-oauth-token
-          filters:
-            tags:
-              only: /^v5.*/
-            branches:
-              ignore: /.*/
-      - deploy-support-assets:
-          context:
-            - docker-hub-creds
-            - git-oauth-token
-          requires:
-            - export-support-assets
-          filters:
-            tags:
-              only: /^v5.*/
-            branches:
-              ignore: /.*/
+      #- deploy:
+      #    build_tag: $CIRCLE_TAG
+      #    final_tag: latest
+      #    context:
+      #      - docker-hub-creds
+      #      - git-oauth-token
+      #    requires:
+      #      - build-hysds_verdi_pge_base
+      #    filters:
+      #      tags:
+      #        only: /^v5.*/
+      #      branches:
+      #        ignore: /.*/
+      #- export-support-assets:
+      #    context:
+      #      - docker-hub-creds
+      #      - git-oauth-token
+      #    filters:
+      #      tags:
+      #        only: /^v5.*/
+      #      branches:
+      #        ignore: /.*/
+      #- deploy-support-assets:
+      #    context:
+      #      - docker-hub-creds
+      #      - git-oauth-token
+      #    requires:
+      #      - export-support-assets
+      #    filters:
+      #      tags:
+      #        only: /^v5.*/
+      #      branches:
+      #        ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1201,36 +1201,36 @@ workflows:
               only: /^v5.*/
             branches:
               ignore: /.*/
-      #- deploy:
-      #    build_tag: $CIRCLE_TAG
-      #    final_tag: latest
-      #    context:
-      #      - docker-hub-creds
-      #      - git-oauth-token
-      #    requires:
-      #      - build-hysds_verdi_pge_base
-      #    filters:
-      #      tags:
-      #        only: /^v5.*/
-      #      branches:
-      #        ignore: /.*/
-      #- export-support-assets:
-      #    context:
-      #      - docker-hub-creds
-      #      - git-oauth-token
-      #    filters:
-      #      tags:
-      #        only: /^v5.*/
-      #      branches:
-      #        ignore: /.*/
-      #- deploy-support-assets:
-      #    context:
-      #      - docker-hub-creds
-      #      - git-oauth-token
-      #    requires:
-      #      - export-support-assets
-      #    filters:
-      #      tags:
-      #        only: /^v5.*/
-      #      branches:
-      #        ignore: /.*/
+      - deploy:
+          build_tag: $CIRCLE_TAG
+          final_tag: latest
+          context:
+            - docker-hub-creds
+            - git-oauth-token
+          requires:
+            - build-hysds_verdi_pge_base
+          filters:
+            tags:
+              only: /^v5.*/
+            branches:
+              ignore: /.*/
+      - export-support-assets:
+          context:
+            - docker-hub-creds
+            - git-oauth-token
+          filters:
+            tags:
+              only: /^v5.*/
+            branches:
+              ignore: /.*/
+      - deploy-support-assets:
+          context:
+            - docker-hub-creds
+            - git-oauth-token
+          requires:
+            - export-support-assets
+          filters:
+            tags:
+              only: /^v5.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -894,7 +894,7 @@ workflows:
             branches:
               only: HC-522
       - build-hysds_verdi_pge_base:
-          puppet_branch: docker
+          puppet_branch: HC-522
           build_tag: ""
           final_tag: HC-522
           framework_branch: HC-522

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -898,7 +898,7 @@ workflows:
           build_tag: ""
           final_tag: HC-522
           framework_branch: develop
-          hysds_release: HC-522
+          hysds_release: develop
           base_branch: HC-522
           context:
             - docker-hub-creds

--- a/install.sh
+++ b/install.sh
@@ -213,13 +213,7 @@ source $INSTALL_DIR/bin/activate
 
 
 # Pin until https://github.com/pypa/setuptools/issues/4399 is fixed
-echo "*****pip list before*****"
-pip list
-echo "*****pip list before*****"
 pip install -U pip 'setuptools<70.0'
-echo "*****pip list after*****"
-pip list
-echo "*****pip list after*****"
 
 # Need to install backoff due to download_assets needing it
 pip install backoff
@@ -227,7 +221,7 @@ pip install backoff
 
 # force install supervisor
 if [ ! -e "$INSTALL_DIR/bin/supervisord" ]; then
-  pip install --ignore-installed supervisor
+  pip install supervisor
 fi
 
 

--- a/install.sh
+++ b/install.sh
@@ -212,10 +212,16 @@ fi
 source $INSTALL_DIR/bin/activate
 
 
+# Pin until https://github.com/pypa/setuptools/issues/4399 is fixed
+echo "*****pip list before*****"
+pip list
+echo "*****pip list before*****"
+pip install "setuptools<70.0"
 # install latest pip and setuptools
 pip install -U pip
-# Pin until https://github.com/pypa/setuptools/issues/4399 is fixed
-pip install "setuptools<70.0"
+echo "*****pip list after*****"
+pip list
+echo "*****pip list after*****"
 
 # Need to install backoff due to download_assets needing it
 pip install backoff

--- a/install.sh
+++ b/install.sh
@@ -203,7 +203,7 @@ fi
 
 # create virtualenv if not found
 if [ ! -e "$INSTALL_DIR/bin/activate" ]; then
-  virtualenv --system-site-packages $INSTALL_DIR
+  virtualenv --system-site-packages $INSTALL_DIR --no-setuptools
   echo "Created virtualenv at $INSTALL_DIR."
 fi
 
@@ -216,9 +216,7 @@ source $INSTALL_DIR/bin/activate
 echo "*****pip list before*****"
 pip list
 echo "*****pip list before*****"
-pip install "setuptools<70.0"
-# install latest pip and setuptools
-pip install -U pip
+pip install -U pip 'setuptools<70.0'
 echo "*****pip list after*****"
 pip list
 echo "*****pip list after*****"

--- a/install.sh
+++ b/install.sh
@@ -214,7 +214,8 @@ source $INSTALL_DIR/bin/activate
 
 # install latest pip and setuptools
 pip install -U pip
-pip install -U setuptools
+# Pin until https://github.com/pypa/setuptools/issues/4399 is fixed
+pip install "setuptools<70.0"
 
 # Need to install backoff due to download_assets needing it
 pip install backoff

--- a/install.sh
+++ b/install.sh
@@ -213,6 +213,7 @@ source $INSTALL_DIR/bin/activate
 
 
 # Pin until https://github.com/pypa/setuptools/issues/4399 is fixed
+# Related PR: https://github.com/pypa/setuptools/pull/4422
 pip install -U pip 'setuptools<70.0'
 
 # Need to install backoff due to download_assets needing it


### PR DESCRIPTION
With the setuptools 70.0 release, it is found that it broke our builds due to the issue described here:

https://github.com/pypa/setuptools/issues/4399 is fixed

The temporary resolution is to pin setuptools to less than 70.0 until this issue is fixed. Just a heads up, there is a related PR that contains the above-mentioned fix: https://github.com/pypa/setuptools/pull/4422

