### PR TITLE
hot-update: Updated CircleCI configuration to point to the latest docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -856,7 +856,7 @@ workflows:
             - git-oauth-token
           filters:
             branches:
-              only: develop
+              only: HC-522-update
       - build-hysds_dev:
           branch: HC-522-update
           build_tag: ""
@@ -868,7 +868,7 @@ workflows:
             - build-hysds_base
           filters:
             branches:
-              only: develop
+              only: HC-522-update
       - build-hysds_cuda_base:
           branch: HC-522-update
           build_tag: ""
@@ -880,7 +880,7 @@ workflows:
             - build-hysds_base
           filters:
             branches:
-              only: develop
+              only: HC-522-update
       - build-hysds_cuda_dev:
           branch: HC-522-update
           build_tag: ""
@@ -892,7 +892,7 @@ workflows:
             - build-hysds_cuda_base
           filters:
             branches:
-              only: develop
+              only: HC-522-update
       - build-hysds_verdi_pge_base:
           puppet_branch: HC-522-update
           build_tag: ""
@@ -910,12 +910,12 @@ workflows:
             branches:
               only: HC-522-update
       - build-hysds_cuda_pge_base:
-          puppet_branch: docker
+          puppet_branch: HC-522-update
           build_tag: ""
-          final_tag: develop
-          framework_branch: develop
-          hysds_release: develop
-          base_branch: develop
+          final_tag: HC-522-update
+          framework_branch: HC-522-update
+          hysds_release: HC-522-update
+          base_branch: HC-522-update
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -924,7 +924,7 @@ workflows:
             - build-hysds_cuda_dev
           filters:
             branches:
-              only: develop
+              only: HC-522-update
       - build-hysds_mozart:
           puppet_branch: docker
           build_tag: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -926,12 +926,12 @@ workflows:
             branches:
               only: HC-522-update
       - build-hysds_mozart:
-          puppet_branch: docker
+          puppet_branch: HC-522-update
           build_tag: ""
-          final_tag: develop
-          framework_branch: develop
+          final_tag: HC-522-update
+          framework_branch: HC-522-update
           hysds_release: develop
-          base_branch: develop
+          base_branch: HC-522-update
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -940,14 +940,14 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: develop
+              only: HC-522-update
       - build-hysds_metrics:
-          puppet_branch: docker
+          puppet_branch: HC-522-update
           build_tag: ""
-          final_tag: develop
-          framework_branch: develop
+          final_tag: HC-522-update
+          framework_branch: HC-522-update
           hysds_release: develop
-          base_branch: develop
+          base_branch: HC-522-update
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -956,14 +956,14 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: develop
+              only: HC-522-update
       - build-hysds_grq:
-          puppet_branch: docker
+          puppet_branch: HC-522-update
           build_tag: ""
-          final_tag: develop
-          framework_branch: develop
+          final_tag: HC-522-update
+          framework_branch: HC-522-update
           hysds_release: develop
-          base_branch: develop
+          base_branch: HC-522-update
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -972,14 +972,14 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: develop
+              only: HC-522-update
       - build-hysds_cont_int:
-          puppet_branch: docker
+          puppet_branch: HC-522-update
           build_tag: ""
-          final_tag: develop
-          framework_branch: develop
+          final_tag: HC-522-update
+          framework_branch: HC-522-update
           hysds_release: develop
-          base_branch: develop
+          base_branch: HC-522-update
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -988,7 +988,7 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: develop
+              only: HC-522-update
       - deploy:
           build_tag: ""
           final_tag: HC-522-update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -908,7 +908,7 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: HC-522-update
+              only: develop
       - build-hysds_cuda_pge_base:
           puppet_branch: docker
           build_tag: ""
@@ -924,7 +924,7 @@ workflows:
             - build-hysds_cuda_dev
           filters:
             branches:
-              only: HC-522-update
+              only: develop
       - build-hysds_mozart:
           puppet_branch: docker
           build_tag: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -914,7 +914,7 @@ workflows:
           build_tag: ""
           final_tag: HC-522-update
           framework_branch: HC-522-update
-          hysds_release: HC-522-update
+          hysds_release: develop
           base_branch: HC-522-update
           context:
             - docker-hub-creds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -848,9 +848,9 @@ workflows:
             branches:
               only: develop
       - build-hysds_base:
-          branch: develop
+          branch: HC-522-update
           build_tag: ""
-          final_tag: develop
+          final_tag: HC-522-update
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -858,9 +858,9 @@ workflows:
             branches:
               only: develop
       - build-hysds_dev:
-          branch: develop
+          branch: HC-522-update
           build_tag: ""
-          final_tag: develop
+          final_tag: HC-522-update
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -870,9 +870,9 @@ workflows:
             branches:
               only: develop
       - build-hysds_cuda_base:
-          branch: develop
+          branch: HC-522-update
           build_tag: ""
-          final_tag: develop
+          final_tag: HC-522-update
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -882,9 +882,9 @@ workflows:
             branches:
               only: develop
       - build-hysds_cuda_dev:
-          branch: develop
+          branch: HC-522-update
           build_tag: ""
-          final_tag: develop
+          final_tag: HC-522-update
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -894,12 +894,12 @@ workflows:
             branches:
               only: develop
       - build-hysds_verdi_pge_base:
-          puppet_branch: docker
+          puppet_branch: HC-522-update
           build_tag: ""
-          final_tag: develop
-          framework_branch: develop
+          final_tag: HC-522-update
+          framework_branch: HC-522-update
           hysds_release: develop
-          base_branch: develop
+          base_branch: HC-522-update
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -908,7 +908,7 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: develop
+              only: HC-522-update
       - build-hysds_cuda_pge_base:
           puppet_branch: docker
           build_tag: ""
@@ -991,7 +991,7 @@ workflows:
               only: develop
       - deploy:
           build_tag: ""
-          final_tag: develop
+          final_tag: HC-522-update
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -999,7 +999,7 @@ workflows:
             - build-hysds_verdi_pge_base
           filters:
             branches:
-              only: develop
+              only: HC-522-update
   build-deploy-release:
     jobs:
       - build-redis:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             pytest
   build-redis:
     docker:
-      - image: docker:20.10.23-git
+      - image: docker:24.0.9-git
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -54,7 +54,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.23
+          version: default
       - install_deps
       - prep_env
       - run:
@@ -79,7 +79,7 @@ jobs:
             docker push hysds/redis:<< parameters.final_tag >>
   build-elasticsearch:
     docker:
-      - image: docker:20.10.23-git
+      - image: docker:24.0.9-git
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -92,7 +92,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.23
+          version: default
       - install_deps
       - prep_env
       - run:
@@ -113,7 +113,7 @@ jobs:
             docker push hysds/elasticsearch:<< parameters.final_tag >>
   build-rabbitmq:
     docker:
-      - image: docker:20.10.23-git
+      - image: docker:24.0.9-git
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -132,7 +132,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.23
+          version: default
       - install_deps
       - prep_env
       - run:
@@ -155,7 +155,7 @@ jobs:
             docker push hysds/rabbitmq:<< parameters.final_tag >>
   build-hysds_base:
     docker:
-      - image: docker:20.10.23-git
+      - image: docker:24.0.9-git
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -174,7 +174,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.23
+          version: default
       - install_deps
       - prep_env
       - run:
@@ -197,7 +197,7 @@ jobs:
             docker push hysds/base:<< parameters.final_tag >>
   build-hysds_cuda_base:
     docker:
-      - image: docker:20.10.23-git
+      - image: docker:24.0.9-git
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -216,7 +216,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.23
+          version: default
       - install_deps
       - prep_env
       - run:
@@ -241,7 +241,7 @@ jobs:
             docker push hysds/cuda-base:<< parameters.final_tag >>
   build-hysds_dev:
     docker:
-      - image: docker:20.10.23-git
+      - image: docker:24.0.9-git
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -260,7 +260,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.23
+          version: default
       - install_deps
       - prep_env
       - run:
@@ -285,7 +285,7 @@ jobs:
             docker push hysds/dev:<< parameters.final_tag >>
   build-hysds_cuda_dev:
     docker:
-      - image: docker:20.10.23-git
+      - image: docker:24.0.9-git
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -304,7 +304,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.23
+          version: default
       - install_deps
       - prep_env
       - run:
@@ -329,7 +329,7 @@ jobs:
             docker push hysds/cuda-dev:<< parameters.final_tag >>
   build-hysds_verdi_pge_base:
     docker:
-      - image: docker:20.10.23-git
+      - image: docker:24.0.9-git
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -357,7 +357,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.23
+          version: default
       - install_deps
       - prep_env
       - run:
@@ -398,7 +398,7 @@ jobs:
             - "*"
   build-hysds_cuda_pge_base:
     docker:
-      - image: docker:20.10.23-git
+      - image: docker:24.0.9-git
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -426,7 +426,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.23
+          version: default
       - install_deps
       - prep_env
       - run:
@@ -452,7 +452,7 @@ jobs:
             docker push hysds/cuda-pge-base:<< parameters.final_tag >>
   build-hysds_mozart:
     docker:
-      - image: docker:20.10.23-git
+      - image: docker:24.0.9-git
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -480,7 +480,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.23
+          version: default
       - install_deps
       - prep_env
       - run:
@@ -506,7 +506,7 @@ jobs:
             docker push hysds/mozart:<< parameters.final_tag >>
   build-hysds_metrics:
     docker:
-      - image: docker:20.10.23-git
+      - image: docker:24.0.9-git
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -534,7 +534,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.23
+          version: default
       - install_deps
       - prep_env
       - run:
@@ -560,7 +560,7 @@ jobs:
             docker push hysds/metrics:<< parameters.final_tag >>
   build-hysds_grq:
     docker:
-      - image: docker:20.10.23-git
+      - image: docker:24.0.9-git
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -588,7 +588,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.23
+          version: default
       - install_deps
       - prep_env
       - run:
@@ -614,7 +614,7 @@ jobs:
             docker push hysds/grq:<< parameters.final_tag >>
   build-hysds_cont_int:
     docker:
-      - image: docker:20.10.23-git
+      - image: docker:24.0.9-git
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -642,7 +642,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.23
+          version: default
       - install_deps
       - prep_env
       - run:
@@ -718,14 +718,14 @@ jobs:
             gh release upload ${tag} ${file} -R ${org}/${repo} --clobber
   export-support-assets:
     docker:
-      - image: docker:20.10.23-git
+      - image: docker:24.0.9-git
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.23
+          version: default
       - install_deps
       - prep_env
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -848,19 +848,19 @@ workflows:
             branches:
               only: develop
       - build-hysds_base:
-          branch: HC-522-update
+          branch: develop
           build_tag: ""
-          final_tag: HC-522-update
+          final_tag: develop
           context:
             - docker-hub-creds
             - git-oauth-token
           filters:
             branches:
-              only: HC-522-update
+              only: develop
       - build-hysds_dev:
-          branch: HC-522-update
+          branch: develop
           build_tag: ""
-          final_tag: HC-522-update
+          final_tag: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -868,11 +868,11 @@ workflows:
             - build-hysds_base
           filters:
             branches:
-              only: HC-522-update
+              only: develop
       - build-hysds_cuda_base:
-          branch: HC-522-update
+          branch: develop
           build_tag: ""
-          final_tag: HC-522-update
+          final_tag: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -880,11 +880,11 @@ workflows:
             - build-hysds_base
           filters:
             branches:
-              only: HC-522-update
+              only: develop
       - build-hysds_cuda_dev:
-          branch: HC-522-update
+          branch: develop
           build_tag: ""
-          final_tag: HC-522-update
+          final_tag: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -892,14 +892,14 @@ workflows:
             - build-hysds_cuda_base
           filters:
             branches:
-              only: HC-522-update
+              only: develop
       - build-hysds_verdi_pge_base:
-          puppet_branch: HC-522-update
+          puppet_branch: docker
           build_tag: ""
-          final_tag: HC-522-update
-          framework_branch: HC-522-update
+          final_tag: develop
+          framework_branch: develop
           hysds_release: develop
-          base_branch: HC-522-update
+          base_branch: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -910,12 +910,12 @@ workflows:
             branches:
               only: HC-522-update
       - build-hysds_cuda_pge_base:
-          puppet_branch: HC-522-update
+          puppet_branch: docker
           build_tag: ""
-          final_tag: HC-522-update
-          framework_branch: HC-522-update
+          final_tag: develop
+          framework_branch: develop
           hysds_release: develop
-          base_branch: HC-522-update
+          base_branch: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -926,12 +926,12 @@ workflows:
             branches:
               only: HC-522-update
       - build-hysds_mozart:
-          puppet_branch: HC-522-update
+          puppet_branch: docker
           build_tag: ""
-          final_tag: HC-522-update
-          framework_branch: HC-522-update
+          final_tag: develop
+          framework_branch: develop
           hysds_release: develop
-          base_branch: HC-522-update
+          base_branch: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -940,14 +940,14 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: HC-522-update
+              only: develop
       - build-hysds_metrics:
-          puppet_branch: HC-522-update
+          puppet_branch: docker
           build_tag: ""
-          final_tag: HC-522-update
-          framework_branch: HC-522-update
+          final_tag: develop
+          framework_branch: develop
           hysds_release: develop
-          base_branch: HC-522-update
+          base_branch: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -956,14 +956,14 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: HC-522-update
+              only: develop
       - build-hysds_grq:
-          puppet_branch: HC-522-update
+          puppet_branch: docker
           build_tag: ""
-          final_tag: HC-522-update
-          framework_branch: HC-522-update
+          final_tag: develop
+          framework_branch: develop
           hysds_release: develop
-          base_branch: HC-522-update
+          base_branch: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -972,14 +972,14 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: HC-522-update
+              only: develop
       - build-hysds_cont_int:
-          puppet_branch: HC-522-update
+          puppet_branch: docker
           build_tag: ""
-          final_tag: HC-522-update
-          framework_branch: HC-522-update
+          final_tag: develop
+          framework_branch: develop
           hysds_release: develop
-          base_branch: HC-522-update
+          base_branch: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -988,10 +988,10 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: HC-522-update
+              only: develop
       - deploy:
           build_tag: ""
-          final_tag: HC-522-update
+          final_tag: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -999,7 +999,7 @@ workflows:
             - build-hysds_verdi_pge_base
           filters:
             branches:
-              only: HC-522-update
+              only: develop
   build-deploy-release:
     jobs:
       - build-redis:


### PR DESCRIPTION
The current docker image versions being referenced in the CircleCI configuration is being end-of-life'd by CircleCI. Therefore, there is a need to update them. This PR updates those images to the latest.
