### PR TITLE
HC-568: Pin setuptools to less than 80.0.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -330,7 +330,7 @@ if [[ "$DEV" == 1 ]]; then
   
   
   # clone sdscli package
-  install_dev_repo $OPS sdscli https://github.com/sdskit/sdscli.git
+  install_dev_repo $OPS sdscli https://github.com/sdskit/sdscli.git HC-568
   
   
   # clone grq2 package

--- a/install.sh
+++ b/install.sh
@@ -215,7 +215,7 @@ source $INSTALL_DIR/bin/activate
 
 
 # Combining installs in case we have to pin setuptools in the future
-pip install -U pip setuptools
+pip install -U pip "setuptools<80.0.0"
 
 # Need to install backoff due to download_assets needing it
 pip install backoff

--- a/install.sh
+++ b/install.sh
@@ -215,7 +215,8 @@ source $INSTALL_DIR/bin/activate
 
 
 # Combining installs in case we have to pin setuptools in the future
-pip install -U pip "setuptools<80.0.0"
+#pip install -U pip "setuptools<80.0.0"
+pip install -U pip setuptools future
 
 # Need to install backoff due to download_assets needing it
 pip install backoff

--- a/install.sh
+++ b/install.sh
@@ -215,8 +215,7 @@ source $INSTALL_DIR/bin/activate
 
 
 # Combining installs in case we have to pin setuptools in the future
-#pip install -U pip "setuptools<80.0.0"
-pip install -U pip setuptools future
+pip install -U pip "setuptools<80.0.0"
 
 # Need to install backoff due to download_assets needing it
 pip install backoff

--- a/install.sh
+++ b/install.sh
@@ -330,7 +330,7 @@ if [[ "$DEV" == 1 ]]; then
   
   
   # clone sdscli package
-  install_dev_repo $OPS sdscli https://github.com/sdskit/sdscli.git HC-568
+  install_dev_repo $OPS sdscli https://github.com/sdskit/sdscli.git
   
   
   # clone grq2 package


### PR DESCRIPTION
This PR pins the setuptools installation to less than 80.0.0. This is due to an error that is seen when trying to provision a cluster when using the latest setuptools (80.0.0):

```
 ModuleNotFoundError: No module named 'future'
```

See the associated JIRA ticket for more details on the error. This PR is in conjunction with https://github.com/sdskit/sdscli/pull/111

For testing, I kludged the terraform on SWOT to take in these core updates and ran a dev-e2e test and it passed:

![image](https://github.com/user-attachments/assets/88a31af2-c543-48e7-bcc3-5da76a2f2167)
