### PR TITLE
HC-563: Update install.sh with update github repo path to sdscli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -908,7 +908,7 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: develop
+              only: HC-563
       - build-hysds_cuda_pge_base:
           puppet_branch: HC-563
           build_tag: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -848,19 +848,19 @@ workflows:
             branches:
               only: develop
       - build-hysds_base:
-          branch: develop
+          branch: HC-563
           build_tag: ""
-          final_tag: develop
+          final_tag: HC-563
           context:
             - docker-hub-creds
             - git-oauth-token
           filters:
             branches:
-              only: develop
+              only: HC-563
       - build-hysds_dev:
-          branch: develop
+          branch: HC-563
           build_tag: ""
-          final_tag: develop
+          final_tag: HC-563
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -868,11 +868,11 @@ workflows:
             - build-hysds_base
           filters:
             branches:
-              only: develop
+              only: HC-563
       - build-hysds_cuda_base:
-          branch: develop
+          branch: HC-563
           build_tag: ""
-          final_tag: develop
+          final_tag: HC-563
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -880,11 +880,11 @@ workflows:
             - build-hysds_base
           filters:
             branches:
-              only: develop
+              only: HC-563
       - build-hysds_cuda_dev:
           branch: develop
           build_tag: ""
-          final_tag: develop
+          final_tag: HC-563
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -892,14 +892,14 @@ workflows:
             - build-hysds_cuda_base
           filters:
             branches:
-              only: develop
+              only: HC-563
       - build-hysds_verdi_pge_base:
-          puppet_branch: docker
+          puppet_branch: HC-563
           build_tag: ""
-          final_tag: develop
-          framework_branch: develop
+          final_tag: HC-563
+          framework_branch: HC-563
           hysds_release: develop
-          base_branch: develop
+          base_branch: HC-563
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -910,12 +910,12 @@ workflows:
             branches:
               only: develop
       - build-hysds_cuda_pge_base:
-          puppet_branch: docker
+          puppet_branch: HC-563
           build_tag: ""
-          final_tag: develop
-          framework_branch: develop
+          final_tag: HC-563
+          framework_branch: HC-563
           hysds_release: develop
-          base_branch: develop
+          base_branch: HC-563
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -924,14 +924,14 @@ workflows:
             - build-hysds_cuda_dev
           filters:
             branches:
-              only: develop
+              only: HC-563
       - build-hysds_mozart:
-          puppet_branch: docker
+          puppet_branch: HC-563
           build_tag: ""
-          final_tag: develop
-          framework_branch: develop
+          final_tag: HC-563
+          framework_branch: HC-563
           hysds_release: develop
-          base_branch: develop
+          base_branch: HC-563
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -940,14 +940,14 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: develop
+              only: HC-563
       - build-hysds_metrics:
-          puppet_branch: docker
+          puppet_branch: HC-563
           build_tag: ""
-          final_tag: develop
-          framework_branch: develop
+          final_tag: HC-563
+          framework_branch: HC-563
           hysds_release: develop
-          base_branch: develop
+          base_branch: HC-563
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -956,14 +956,14 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: develop
+              only: HC-563
       - build-hysds_grq:
-          puppet_branch: docker
+          puppet_branch: HC-563
           build_tag: ""
-          final_tag: develop
-          framework_branch: develop
+          final_tag: HC-563
+          framework_branch: HC-563
           hysds_release: develop
-          base_branch: develop
+          base_branch: HC-563
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -972,14 +972,14 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: develop
+              only: HC-563
       - build-hysds_cont_int:
-          puppet_branch: docker
+          puppet_branch: HC-563
           build_tag: ""
-          final_tag: develop
-          framework_branch: develop
+          final_tag: HC-563
+          framework_branch: HC-563
           hysds_release: develop
-          base_branch: develop
+          base_branch: HC-563
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -988,10 +988,10 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: develop
+              only: HC-563
       - deploy:
           build_tag: ""
-          final_tag: develop
+          final_tag: HC-563
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -999,7 +999,7 @@ workflows:
             - build-hysds_verdi_pge_base
           filters:
             branches:
-              only: develop
+              only: HC-563
   build-deploy-release:
     jobs:
       - build-redis:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -848,19 +848,19 @@ workflows:
             branches:
               only: develop
       - build-hysds_base:
-          branch: HC-563
+          branch: develop
           build_tag: ""
-          final_tag: HC-563
+          final_tag: develop
           context:
             - docker-hub-creds
             - git-oauth-token
           filters:
             branches:
-              only: HC-563
+              only: develop
       - build-hysds_dev:
           branch: HC-563
           build_tag: ""
-          final_tag: HC-563
+          final_tag: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -868,11 +868,11 @@ workflows:
             - build-hysds_base
           filters:
             branches:
-              only: HC-563
+              only: develop
       - build-hysds_cuda_base:
-          branch: HC-563
+          branch: develop
           build_tag: ""
-          final_tag: HC-563
+          final_tag: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -880,11 +880,11 @@ workflows:
             - build-hysds_base
           filters:
             branches:
-              only: HC-563
+              only: develop
       - build-hysds_cuda_dev:
           branch: develop
           build_tag: ""
-          final_tag: HC-563
+          final_tag: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -892,14 +892,14 @@ workflows:
             - build-hysds_cuda_base
           filters:
             branches:
-              only: HC-563
+              only: develop
       - build-hysds_verdi_pge_base:
-          puppet_branch: HC-563
+          puppet_branch: develop
           build_tag: ""
-          final_tag: HC-563
-          framework_branch: HC-563
+          final_tag: develop
+          framework_branch: develop
           hysds_release: develop
-          base_branch: HC-563
+          base_branch: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -908,14 +908,14 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: HC-563
+              only: develop
       - build-hysds_cuda_pge_base:
-          puppet_branch: HC-563
+          puppet_branch: docker
           build_tag: ""
-          final_tag: HC-563
-          framework_branch: HC-563
+          final_tag: develop
+          framework_branch: develop
           hysds_release: develop
-          base_branch: HC-563
+          base_branch: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -924,14 +924,14 @@ workflows:
             - build-hysds_cuda_dev
           filters:
             branches:
-              only: HC-563
+              only: develop
       - build-hysds_mozart:
-          puppet_branch: HC-563
+          puppet_branch: docker
           build_tag: ""
-          final_tag: HC-563
-          framework_branch: HC-563
+          final_tag: develop
+          framework_branch: develop
           hysds_release: develop
-          base_branch: HC-563
+          base_branch: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -940,14 +940,14 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: HC-563
+              only: develop
       - build-hysds_metrics:
-          puppet_branch: HC-563
+          puppet_branch: docker
           build_tag: ""
-          final_tag: HC-563
-          framework_branch: HC-563
+          final_tag: develop
+          framework_branch: develop
           hysds_release: develop
-          base_branch: HC-563
+          base_branch: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -956,14 +956,14 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: HC-563
+              only: develop
       - build-hysds_grq:
-          puppet_branch: HC-563
+          puppet_branch: docker
           build_tag: ""
-          final_tag: HC-563
-          framework_branch: HC-563
+          final_tag: develop
+          framework_branch: develop
           hysds_release: develop
-          base_branch: HC-563
+          base_branch: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -972,14 +972,14 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: HC-563
+              only: develop
       - build-hysds_cont_int:
-          puppet_branch: HC-563
+          puppet_branch: docker
           build_tag: ""
-          final_tag: HC-563
-          framework_branch: HC-563
+          final_tag: develop
+          framework_branch: develop
           hysds_release: develop
-          base_branch: HC-563
+          base_branch: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -988,10 +988,10 @@ workflows:
             - build-hysds_dev
           filters:
             branches:
-              only: HC-563
+              only: develop
       - deploy:
           build_tag: ""
-          final_tag: HC-563
+          final_tag: develop
           context:
             - docker-hub-creds
             - git-oauth-token
@@ -999,7 +999,7 @@ workflows:
             - build-hysds_verdi_pge_base
           filters:
             branches:
-              only: HC-563
+              only: develop
   build-deploy-release:
     jobs:
       - build-redis:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -858,7 +858,7 @@ workflows:
             branches:
               only: develop
       - build-hysds_dev:
-          branch: HC-563
+          branch: develop
           build_tag: ""
           final_tag: develop
           context:
@@ -894,7 +894,7 @@ workflows:
             branches:
               only: develop
       - build-hysds_verdi_pge_base:
-          puppet_branch: develop
+          puppet_branch: docker
           build_tag: ""
           final_tag: develop
           framework_branch: develop

--- a/install.sh
+++ b/install.sh
@@ -291,24 +291,24 @@ cd $OPS
 # install dev environment
 if [[ "$DEV" == 1 ]]; then
   # clone prov_es package
-  install_dev_repo $OPS prov_es https://github.com/hysds/prov_es.git
+  install_dev_repo $OPS prov_es https://github.com/hysds/prov_es.git HC-563
   
   
   # clone osaka package
   pip install -U pyasn1
   pip install -U pyasn1-modules
   pip install -U python-dateutil
-  install_dev_repo $OPS osaka https://github.com/hysds/osaka.git
+  install_dev_repo $OPS osaka https://github.com/hysds/osaka.git HC-563
   
   
   # clone hysds_commons package
-  install_dev_repo $OPS hysds_commons https://github.com/hysds/hysds_commons.git
+  install_dev_repo $OPS hysds_commons https://github.com/hysds/hysds_commons.git HC-563
   
   
   # clone hysds package
   cd $OPS
   PACKAGE=hysds
-  clone_dev_repo $OPS $PACKAGE https://github.com/hysds/hysds.git
+  clone_dev_repo $OPS $PACKAGE https://github.com/hysds/hysds.git HC-563
   cd $OPS/$PACKAGE
   pip install -e .
   if [ "$?" -ne 0 ]; then
@@ -318,27 +318,27 @@ if [[ "$DEV" == 1 ]]; then
   
   
   # clone sciflo package
-  install_dev_repo $OPS sciflo https://github.com/hysds/sciflo.git
+  install_dev_repo $OPS sciflo https://github.com/hysds/sciflo.git HC-563
   
   
   # clone chimera package
-  install_dev_repo $OPS chimera https://github.com/hysds/chimera.git
+  install_dev_repo $OPS chimera https://github.com/hysds/chimera.git HC-563
   
   
   # clone mozart package
-  install_dev_repo $OPS mozart https://github.com/hysds/mozart.git
+  install_dev_repo $OPS mozart https://github.com/hysds/mozart.git HC-563
   
   
   # clone sdscli package
-  install_dev_repo $OPS sdscli https://github.com/sdskit/sdscli.git
+  install_dev_repo $OPS sdscli https://github.com/sdskit/sdscli.git HC-563
   
   
   # clone grq2 package
-  install_dev_repo $OPS grq2 https://github.com/hysds/grq2.git
+  install_dev_repo $OPS grq2 https://github.com/hysds/grq2.git HC-563
   
   
   # clone pele package
-  install_dev_repo $OPS pele https://github.com/hysds/pele.git
+  install_dev_repo $OPS pele https://github.com/hysds/pele.git HC-563
 
 
   # clone hysds_ui package
@@ -346,15 +346,15 @@ if [[ "$DEV" == 1 ]]; then
   
   
   # clone spyddder-man package
-  clone_dev_repo $OPS spyddder-man https://github.com/hysds/spyddder-man.git
+  clone_dev_repo $OPS spyddder-man https://github.com/hysds/spyddder-man.git HC-563
   
   
   # clone lightweight-jobs package
-  clone_dev_repo $OPS lightweight-jobs https://github.com/hysds/lightweight-jobs.git
+  clone_dev_repo $OPS lightweight-jobs https://github.com/hysds/lightweight-jobs.git HC-563
   
   
   # clone container-builder package
-  clone_dev_repo $OPS container-builder https://github.com/hysds/container-builder.git
+  clone_dev_repo $OPS container-builder https://github.com/hysds/container-builder.git HC-563
   
   
   # clone s3-bucket-listing package
@@ -366,7 +366,7 @@ if [[ "$DEV" == 1 ]]; then
   
   
   # clone hysds-cloud-functions package
-  clone_dev_repo $OPS hysds-cloud-functions https://github.com/hysds/hysds-cloud-functions.git
+  clone_dev_repo $OPS hysds-cloud-functions https://github.com/hysds/hysds-cloud-functions.git HC-563
 
   # download latest develop verdi image
   if [[ "$COMPONENT" == "mozart" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@ BASE_PATH=$(cd "${BASE_PATH}"; pwd)
 # turn on extglob
 shopt -s extglob
 
+set -ex
 
 cmdname=$(basename $0)
 

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@ BASE_PATH=$(cd "${BASE_PATH}"; pwd)
 # turn on extglob
 shopt -s extglob
 
+
 cmdname=$(basename $0)
 
 
@@ -290,24 +291,24 @@ cd $OPS
 # install dev environment
 if [[ "$DEV" == 1 ]]; then
   # clone prov_es package
-  install_dev_repo $OPS prov_es https://github.com/hysds/prov_es.git HC-563
+  install_dev_repo $OPS prov_es https://github.com/hysds/prov_es.git
   
   
   # clone osaka package
   pip install -U pyasn1
   pip install -U pyasn1-modules
   pip install -U python-dateutil
-  install_dev_repo $OPS osaka https://github.com/hysds/osaka.git HC-563
+  install_dev_repo $OPS osaka https://github.com/hysds/osaka.git
   
   
   # clone hysds_commons package
-  install_dev_repo $OPS hysds_commons https://github.com/hysds/hysds_commons.git HC-563
+  install_dev_repo $OPS hysds_commons https://github.com/hysds/hysds_commons.git
   
   
   # clone hysds package
   cd $OPS
   PACKAGE=hysds
-  clone_dev_repo $OPS $PACKAGE https://github.com/hysds/hysds.git HC-563
+  clone_dev_repo $OPS $PACKAGE https://github.com/hysds/hysds.git
   cd $OPS/$PACKAGE
   pip install -e .
   if [ "$?" -ne 0 ]; then
@@ -317,27 +318,27 @@ if [[ "$DEV" == 1 ]]; then
   
   
   # clone sciflo package
-  install_dev_repo $OPS sciflo https://github.com/hysds/sciflo.git HC-563
+  install_dev_repo $OPS sciflo https://github.com/hysds/sciflo.git
   
   
   # clone chimera package
-  install_dev_repo $OPS chimera https://github.com/hysds/chimera.git HC-563
+  install_dev_repo $OPS chimera https://github.com/hysds/chimera.git
   
   
   # clone mozart package
-  install_dev_repo $OPS mozart https://github.com/hysds/mozart.git HC-563
+  install_dev_repo $OPS mozart https://github.com/hysds/mozart.git
   
   
   # clone sdscli package
-  install_dev_repo $OPS sdscli https://github.com/sdskit/sdscli.git HC-563
+  install_dev_repo $OPS sdscli https://github.com/hysds/sdscli.git
   
   
   # clone grq2 package
-  install_dev_repo $OPS grq2 https://github.com/hysds/grq2.git HC-563
+  install_dev_repo $OPS grq2 https://github.com/hysds/grq2.git
   
   
   # clone pele package
-  install_dev_repo $OPS pele https://github.com/hysds/pele.git HC-563
+  install_dev_repo $OPS pele https://github.com/hysds/pele.git
 
 
   # clone hysds_ui package
@@ -345,15 +346,15 @@ if [[ "$DEV" == 1 ]]; then
   
   
   # clone spyddder-man package
-  clone_dev_repo $OPS spyddder-man https://github.com/hysds/spyddder-man.git HC-563
+  clone_dev_repo $OPS spyddder-man https://github.com/hysds/spyddder-man.git
   
   
   # clone lightweight-jobs package
-  clone_dev_repo $OPS lightweight-jobs https://github.com/hysds/lightweight-jobs.git HC-563
+  clone_dev_repo $OPS lightweight-jobs https://github.com/hysds/lightweight-jobs.git
   
   
   # clone container-builder package
-  clone_dev_repo $OPS container-builder https://github.com/hysds/container-builder.git HC-563
+  clone_dev_repo $OPS container-builder https://github.com/hysds/container-builder.git
   
   
   # clone s3-bucket-listing package
@@ -365,7 +366,7 @@ if [[ "$DEV" == 1 ]]; then
   
   
   # clone hysds-cloud-functions package
-  clone_dev_repo $OPS hysds-cloud-functions https://github.com/hysds/hysds-cloud-functions.git HC-563
+  clone_dev_repo $OPS hysds-cloud-functions https://github.com/hysds/hysds-cloud-functions.git
 
   # download latest develop verdi image
   if [[ "$COMPONENT" == "mozart" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -6,8 +6,6 @@ BASE_PATH=$(cd "${BASE_PATH}"; pwd)
 # turn on extglob
 shopt -s extglob
 
-set -ex
-
 cmdname=$(basename $0)
 
 


### PR DESCRIPTION
The SDSCLI repo has been moved to the hysds org. So, this PR updates the install.sh script to reference this new path.