### PR TITLE
hot-fix: Updates the build-redis job to use a large resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
-    #resource_class: large
+    resource_class: large
     parameters:
       org:
         type: string
@@ -2099,11 +2099,11 @@ workflows:
           context:
             - docker-hub-creds
             - git-oauth-token
-          requires:
-            - build-hysds_base-manifest
+          # requires:
+          #   - build-hysds_base-manifest
           filters:
             branches:
-              only: develop
+              only: hot-fix-build-redis
       - build-elasticsearch:
           build_tag: ""
           final_tag: develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2099,11 +2099,11 @@ workflows:
           context:
             - docker-hub-creds
             - git-oauth-token
-          # requires:
-          #   - build-hysds_base-manifest
+          requires:
+            - build-hysds_base-manifest
           filters:
             branches:
-              only: hot-fix-build-redis
+              only: develop
       - build-elasticsearch:
           build_tag: ""
           final_tag: develop


### PR DESCRIPTION
This will help with performance issues seen when using the default medium resource class due to the QEMU