### PR TITLE
HC-628: Updated to support the downloading of a chunked up lightweight jobs SDS package

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -308,7 +308,7 @@ if [[ "$DEV" == 1 ]]; then
   # clone hysds package
   cd $OPS
   PACKAGE=hysds
-  clone_dev_repo $OPS $PACKAGE https://github.com/hysds/hysds.git
+  clone_dev_repo $OPS $PACKAGE https://github.com/hysds/hysds.git HC-630
   cd $OPS/$PACKAGE
   pip install -e .
   if [ "$?" -ne 0 ]; then

--- a/install.sh
+++ b/install.sh
@@ -510,7 +510,17 @@ fi
 # additional tasks if installing mozart component
 if [[ "$COMPONENT" == "mozart" ]]; then
   # download hysds core packages and docker registry image if mozart
-  ${BASE_PATH}/download_latest.py $API_URL hysds lightweight-jobs -o ${INSTALL_DIR}/pkgs -r "^container-hysds_lightweight-jobs-v2"
+  ${BASE_PATH}/download_latest.py $API_URL hysds lightweight-jobs -o ${INSTALL_DIR}/pkgs -r "^container-hysds_lightweight-jobs-(v2|hc-628)"
+
+  # Check if we downloaded part files and reassemble
+  if ls ${INSTALL_DIR}/pkgs/container-hysds_lightweight-jobs-*.part-* 1> /dev/null 2>&1; then
+    echo "Reassembling chunked package..."
+    cd ${INSTALL_DIR}/pkgs
+    base_file=$(ls container-hysds_lightweight-jobs-*.part-aa | sed 's/\.part-aa$//')
+    cat ${base_file}.part-* > ${base_file}
+    rm ${base_file}.part-*
+  fi
+
   ${BASE_PATH}/download_latest.py $API_URL hysds hysds-dockerfiles -o ${INSTALL_DIR}/pkgs -r "^docker-registry"
   ${BASE_PATH}/download_latest.py $API_URL hysds hysds-dockerfiles -o ${INSTALL_DIR}/pkgs -r "^logstash-"
 

--- a/install.sh
+++ b/install.sh
@@ -510,7 +510,7 @@ fi
 # additional tasks if installing mozart component
 if [[ "$COMPONENT" == "mozart" ]]; then
   # download hysds core packages and docker registry image if mozart
-  ${BASE_PATH}/download_latest.py $API_URL hysds lightweight-jobs -o ${INSTALL_DIR}/pkgs -r "^container-hysds_lightweight-jobs-(v2|hc-628)"
+  ${BASE_PATH}/download_latest.py $API_URL hysds lightweight-jobs -o ${INSTALL_DIR}/pkgs -r "^container-hysds_lightweight-jobs-v2"
 
   # Check if we downloaded part files and reassemble
   if ls ${INSTALL_DIR}/pkgs/container-hysds_lightweight-jobs-*.part-* 1> /dev/null 2>&1; then

--- a/install.sh
+++ b/install.sh
@@ -308,7 +308,7 @@ if [[ "$DEV" == 1 ]]; then
   # clone hysds package
   cd $OPS
   PACKAGE=hysds
-  clone_dev_repo $OPS $PACKAGE https://github.com/hysds/hysds.git HC-630
+  clone_dev_repo $OPS $PACKAGE https://github.com/hysds/hysds.git
   cd $OPS/$PACKAGE
   pip install -e .
   if [ "$?" -ne 0 ]; then


### PR DESCRIPTION
With the merger of https://github.com/hysds/lightweight-jobs/pull/42, this will now give us the ability to create a multi-platform SDS package for lightweight jobs so that it can be deployed onto either an x86 or arm64 host machine. When we create these packages, the size is over the 2 GB limit to upload onto github. Therefore, it needs to be uploaded in parts. The changes made here is intended to support the downloading of this chunked up file.